### PR TITLE
Fix unstable sort in extracted comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="11.0.1"></a>
+# [11.0.1](https://github.com/documentationjs/documentation/compare/v11.0.0...v11.0.1) (2019-05-09)
+
+### Bug Fixes
+
+* Fix unstable sort in comments (https://github.com/1nd/documentation/pull/1)
+
+
 <a name="11.0.0"></a>
 # [11.0.0](https://github.com/documentationjs/documentation/compare/v10.1.0...v11.0.0) (2019-05-08)
 

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -7,6 +7,117 @@ Array [
     "context": Object {
       "loc": SourceLocation {
         "end": Position {
+          "column": 5,
+          "line": 16,
+        },
+        "start": Position {
+          "column": 4,
+          "line": 13,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 17,
+                  "line": 1,
+                  "offset": 16,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This is a number",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 17,
+              "line": 1,
+              "offset": 16,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 17,
+          "line": 1,
+          "offset": 16,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [
+      Object {
+        "commentLineNumber": 0,
+        "message": "@memberof reference to .props not found",
+      },
+    ],
+    "examples": Array [],
+    "implements": Array [],
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 7,
+        "line": 12,
+      },
+      "start": Position {
+        "column": 4,
+        "line": 10,
+      },
+    },
+    "memberof": ".props",
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "myNumber",
+    "namespace": ".myNumber",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": undefined,
+        "name": "myNumber",
+        "scope": "static",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "scope": "static",
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": SourceLocation {
+        "end": Position {
           "column": 1,
           "line": 18,
         },
@@ -179,295 +290,11 @@ Array [
     "todos": Array [],
     "yields": Array [],
   },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": SourceLocation {
-        "end": Position {
-          "column": 5,
-          "line": 16,
-        },
-        "start": Position {
-          "column": 4,
-          "line": 13,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 17,
-                  "line": 1,
-                  "offset": 16,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This is a number",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 17,
-              "line": 1,
-              "offset": 16,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 17,
-          "line": 1,
-          "offset": 16,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [
-      Object {
-        "commentLineNumber": 0,
-        "message": "@memberof reference to .props not found",
-      },
-    ],
-    "examples": Array [],
-    "implements": Array [],
-    "loc": SourceLocation {
-      "end": Position {
-        "column": 7,
-        "line": 12,
-      },
-      "start": Position {
-        "column": 4,
-        "line": 10,
-      },
-    },
-    "memberof": ".props",
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "myNumber",
-    "namespace": ".myNumber",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": undefined,
-        "name": "myNumber",
-        "scope": "static",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "scope": "static",
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
 ]
 `;
 
 exports[`Vue file 1`] = `
 Array [
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": SourceLocation {
-        "end": Position {
-          "column": 1,
-          "line": 20,
-        },
-        "start": Position {
-          "column": 0,
-          "line": 7,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 29,
-                  "line": 1,
-                  "offset": 28,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This Vue Component is a test",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 29,
-              "line": 1,
-              "offset": 28,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 29,
-          "line": 1,
-          "offset": 28,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "loc": SourceLocation {
-      "end": Position {
-        "column": 3,
-        "line": 6,
-      },
-      "start": Position {
-        "column": 0,
-        "line": 3,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "vue.input",
-    "namespace": "vue.input",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": undefined,
-        "name": "vue.input",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [
-      Object {
-        "description": Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "position": Position {
-                    "end": Object {
-                      "column": 21,
-                      "line": 1,
-                      "offset": 20,
-                    },
-                    "indent": Array [],
-                    "start": Object {
-                      "column": 1,
-                      "line": 1,
-                      "offset": 0,
-                    },
-                  },
-                  "type": "text",
-                  "value": "vue-tested component",
-                },
-              ],
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 1,
-                  "offset": 20,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "paragraph",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 21,
-              "line": 1,
-              "offset": 20,
-            },
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "root",
-        },
-        "title": "returns",
-        "type": Object {
-          "name": "vue-tested",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "sees": Array [],
-    "tags": Array [
-      Object {
-        "description": "vue-tested component",
-        "lineNumber": 2,
-        "title": "returns",
-        "type": Object {
-          "name": "vue-tested",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
   Object {
     "augments": Array [],
     "context": Object {
@@ -687,6 +514,179 @@ Array [
     "scope": "static",
     "sees": Array [],
     "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 1,
+          "line": 20,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 7,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 29,
+                  "line": 1,
+                  "offset": 28,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This Vue Component is a test",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 29,
+              "line": 1,
+              "offset": 28,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 29,
+          "line": 1,
+          "offset": 28,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "loc": SourceLocation {
+      "end": Position {
+        "column": 3,
+        "line": 6,
+      },
+      "start": Position {
+        "column": 0,
+        "line": 3,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "vue.input",
+    "namespace": "vue.input",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": undefined,
+        "name": "vue.input",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [
+      Object {
+        "description": Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Position {
+                    "end": Object {
+                      "column": 21,
+                      "line": 1,
+                      "offset": 20,
+                    },
+                    "indent": Array [],
+                    "start": Object {
+                      "column": 1,
+                      "line": 1,
+                      "offset": 0,
+                    },
+                  },
+                  "type": "text",
+                  "value": "vue-tested component",
+                },
+              ],
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 1,
+                  "offset": 20,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "root",
+        },
+        "title": "returns",
+        "type": Object {
+          "name": "vue-tested",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "sees": Array [],
+    "tags": Array [
+      Object {
+        "description": "vue-tested component",
+        "lineNumber": 2,
+        "title": "returns",
+        "type": Object {
+          "name": "vue-tested",
+          "type": "NameExpression",
+        },
+      },
+    ],
     "throws": Array [],
     "todos": Array [],
     "yields": Array [],
@@ -1641,16 +1641,6 @@ exports[`html nested.input.js 1`] = `
               
                 
                 <li><a
-                  href='#customerror'
-                  class=\\"\\">
-                  CustomError
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#bar'
                   class=\\"\\">
                   bar
@@ -1732,6 +1722,16 @@ exports[`html nested.input.js 1`] = `
                   
                   
                 </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#customerror'
+                  class=\\"\\">
+                  CustomError
+                  
+                </a>
                 
                 </li>
               
@@ -2495,80 +2495,6 @@ k.isArrayOfBuffers();</pre>
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='customerror'>
-      CustomError
-    </h3>
-    
-    
-  </div>
-  
-
-  <p>a typedef with nested properties</p>
-
-    <div class='pre p1 fill-light mt0'>CustomError</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>error</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">object</a>)</code>
-          : An error
-
-          
-            <ul>
-              
-                <li><code>error.code</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
-                  
-                  <p>The error's code</p>
-</li>
-              
-                <li><code>error.description</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
-                  
-                  <p>The error's description</p>
-</li>
-              
-            </ul>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='bar'>
       bar
     </h3>
@@ -2938,6 +2864,80 @@ like a <a href=\\"#klass\\">klass</a>. This needs a <a href=\\"https://developer
     </div>
   
 </div>
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='customerror'>
+      CustomError
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>a typedef with nested properties</p>
+
+    <div class='pre p1 fill-light mt0'>CustomError</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>error</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">object</a>)</code>
+          : An error
+
+          
+            <ul>
+              
+                <li><code>error.code</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
+                  
+                  <p>The error's code</p>
+</li>
+              
+                <li><code>error.description</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
+                  
+                  <p>The error's description</p>
+</li>
+              
+            </ul>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
 
   
 
@@ -5171,179 +5171,6 @@ Array [
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-    },
-    "description": "",
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "class",
-    "loc": Object {
-      "end": Object {
-        "column": 1,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [
-        Object {
-          "augments": Array [],
-          "context": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 14,
-                "line": 2,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 2,
-              },
-            },
-          },
-          "description": "",
-          "errors": Array [],
-          "examples": Array [],
-          "implements": Array [],
-          "kind": "function",
-          "loc": Object {
-            "end": Object {
-              "column": 14,
-              "line": 2,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 2,
-            },
-          },
-          "memberof": "z",
-          "members": Object {
-            "events": Array [],
-            "global": Array [],
-            "inner": Array [],
-            "instance": Array [],
-            "static": Array [],
-          },
-          "name": "zMethod",
-          "namespace": "z#zMethod",
-          "params": Array [],
-          "path": Array [
-            Object {
-              "kind": "class",
-              "name": "z",
-            },
-            Object {
-              "kind": "function",
-              "name": "zMethod",
-              "scope": "instance",
-            },
-          ],
-          "properties": Array [],
-          "returns": Array [],
-          "scope": "instance",
-          "sees": Array [],
-          "tags": Array [],
-          "throws": Array [],
-          "todos": Array [],
-          "yields": Array [],
-        },
-      ],
-      "static": Array [],
-    },
-    "name": "z",
-    "namespace": "z",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "class",
-        "name": "z",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 28,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-    },
-    "description": "",
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 28,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "x",
-    "namespace": "x",
-    "params": Array [
-      Object {
-        "lineNumber": 1,
-        "name": "yparam",
-        "title": "param",
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "x",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 1,
           "line": 11,
         },
         "start": Object {
@@ -5565,6 +5392,72 @@ Array [
           "context": Object {
             "loc": Object {
               "end": Object {
+                "column": 31,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 10,
+              },
+            },
+          },
+          "description": "",
+          "errors": Array [],
+          "examples": Array [],
+          "implements": Array [],
+          "kind": "member",
+          "loc": Object {
+            "end": Object {
+              "column": 31,
+              "line": 10,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 10,
+            },
+          },
+          "memberof": "Class",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "staticSetter",
+          "namespace": "Class.staticSetter",
+          "params": Array [
+            Object {
+              "lineNumber": 10,
+              "name": "v",
+              "title": "param",
+            },
+          ],
+          "path": Array [
+            Object {
+              "kind": "class",
+              "name": "Class",
+            },
+            Object {
+              "kind": "member",
+              "name": "staticSetter",
+              "scope": "static",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "static",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+          "yields": Array [],
+        },
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
                 "column": 26,
                 "line": 8,
               },
@@ -5680,72 +5573,6 @@ Array [
           "todos": Array [],
           "yields": Array [],
         },
-        Object {
-          "augments": Array [],
-          "context": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 31,
-                "line": 10,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 10,
-              },
-            },
-          },
-          "description": "",
-          "errors": Array [],
-          "examples": Array [],
-          "implements": Array [],
-          "kind": "member",
-          "loc": Object {
-            "end": Object {
-              "column": 31,
-              "line": 10,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 10,
-            },
-          },
-          "memberof": "Class",
-          "members": Object {
-            "events": Array [],
-            "global": Array [],
-            "inner": Array [],
-            "instance": Array [],
-            "static": Array [],
-          },
-          "name": "staticSetter",
-          "namespace": "Class.staticSetter",
-          "params": Array [
-            Object {
-              "lineNumber": 10,
-              "name": "v",
-              "title": "param",
-            },
-          ],
-          "path": Array [
-            Object {
-              "kind": "class",
-              "name": "Class",
-            },
-            Object {
-              "kind": "member",
-              "name": "staticSetter",
-              "scope": "static",
-            },
-          ],
-          "properties": Array [],
-          "returns": Array [],
-          "scope": "static",
-          "sees": Array [],
-          "tags": Array [],
-          "throws": Array [],
-          "todos": Array [],
-          "yields": Array [],
-        },
       ],
     },
     "name": "Class",
@@ -5769,235 +5596,6 @@ Array [
     ],
     "properties": Array [],
     "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 25,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 3,
-        },
-      },
-    },
-    "description": "",
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "typedef",
-    "loc": Object {
-      "end": Object {
-        "column": 25,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 3,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "T5",
-    "namespace": "T5",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "typedef",
-        "name": "T5",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "type": Object {
-      "name": "boolean",
-      "type": "NameExpression",
-    },
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 18,
-          "line": 5,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 5,
-        },
-      },
-    },
-    "description": "",
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "loc": Object {
-      "end": Object {
-        "column": 18,
-        "line": 5,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 5,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "y2Default",
-    "namespace": "y2Default",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "name": "y2Default",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 31,
-          "line": 8,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 8,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 18,
-                  "line": 1,
-                  "offset": 17,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "Description of y3",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 18,
-              "line": 1,
-              "offset": 17,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 18,
-          "line": 1,
-          "offset": 17,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 24,
-        "line": 7,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 7,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "y4",
-    "namespace": "y4",
-    "params": Array [
-      Object {
-        "lineNumber": 8,
-        "name": "p",
-        "title": "param",
-        "type": Object {
-          "name": "number",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "y4",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [
-      Object {
-        "title": "returns",
-        "type": Object {
-          "type": "VoidLiteral",
-        },
-      },
-    ],
     "sees": Array [],
     "tags": Array [],
     "throws": Array [],
@@ -7031,6 +6629,408 @@ Array [
     "todos": Array [],
     "yields": Array [],
   },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+    },
+    "description": "",
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "typedef",
+    "loc": Object {
+      "end": Object {
+        "column": 25,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 3,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "T5",
+    "namespace": "T5",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "typedef",
+        "name": "T5",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "type": Object {
+      "name": "boolean",
+      "type": "NameExpression",
+    },
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+    },
+    "description": "",
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 28,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "x",
+    "namespace": "x",
+    "params": Array [
+      Object {
+        "lineNumber": 1,
+        "name": "yparam",
+        "title": "param",
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "x",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 5,
+        },
+      },
+    },
+    "description": "",
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "loc": Object {
+      "end": Object {
+        "column": 18,
+        "line": 5,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 5,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "y2Default",
+    "namespace": "y2Default",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "name": "y2Default",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 31,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 8,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 1,
+                  "offset": 17,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "Description of y3",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+          "offset": 17,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 24,
+        "line": 7,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 7,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "y4",
+    "namespace": "y4",
+    "params": Array [
+      Object {
+        "lineNumber": 8,
+        "name": "p",
+        "title": "param",
+        "type": Object {
+          "name": "number",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "y4",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [
+      Object {
+        "title": "returns",
+        "type": Object {
+          "type": "VoidLiteral",
+        },
+      },
+    ],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+    },
+    "description": "",
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "class",
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 14,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+          },
+          "description": "",
+          "errors": Array [],
+          "examples": Array [],
+          "implements": Array [],
+          "kind": "function",
+          "loc": Object {
+            "end": Object {
+              "column": 14,
+              "line": 2,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 2,
+            },
+          },
+          "memberof": "z",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "zMethod",
+          "namespace": "z#zMethod",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": "class",
+              "name": "z",
+            },
+            Object {
+              "kind": "function",
+              "name": "zMethod",
+              "scope": "instance",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "instance",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+          "yields": Array [],
+        },
+      ],
+      "static": Array [],
+    },
+    "name": "z",
+    "namespace": "z",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "class",
+        "name": "z",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
 ]
 `;
 
@@ -7039,54 +7039,44 @@ exports[`outputs document-exported.input.js markdown 1`] = `
 
 ### Table of Contents
 
--   [z][1]
-    -   [zMethod][2]
--   [x][3]
-    -   [Parameters][4]
--   [Class][5]
-    -   [Parameters][6]
-    -   [classMethod][7]
-    -   [classGetter][8]
-    -   [classSetter][9]
-        -   [Parameters][10]
-    -   [staticMethod][11]
-    -   [staticGetter][12]
-    -   [staticSetter][13]
-        -   [Parameters][14]
--   [T5][15]
--   [y2Default][16]
--   [y4][17]
-    -   [Parameters][18]
--   [object][19]
-    -   [method][20]
-    -   [getter][21]
-    -   [setter][22]
-        -   [Parameters][23]
-    -   [prop][24]
-    -   [func][25]
--   [f1][26]
--   [f3][27]
--   [T][28]
--   [T2][29]
--   [T4][30]
--   [f4][31]
-    -   [Parameters][32]
--   [o1][33]
-    -   [om1][34]
--   [f5][35]
+-   [Class][1]
+    -   [Parameters][2]
+    -   [classMethod][3]
+    -   [classGetter][4]
+    -   [classSetter][5]
+        -   [Parameters][6]
+    -   [staticSetter][7]
+        -   [Parameters][8]
+    -   [staticMethod][9]
+    -   [staticGetter][10]
+-   [object][11]
+    -   [method][12]
+    -   [getter][13]
+    -   [setter][14]
+        -   [Parameters][15]
+    -   [prop][16]
+    -   [func][17]
+-   [f1][18]
+-   [f3][19]
+-   [T][20]
+-   [T2][21]
+-   [T4][22]
+-   [f4][23]
+    -   [Parameters][24]
+-   [o1][25]
+    -   [om1][26]
+-   [f5][27]
+    -   [Parameters][28]
+-   [o2][29]
+    -   [om2][30]
+-   [T5][31]
+-   [x][32]
+    -   [Parameters][33]
+-   [y2Default][34]
+-   [y4][35]
     -   [Parameters][36]
--   [o2][37]
-    -   [om2][38]
-
-## z
-
-### zMethod
-
-## x
-
-### Parameters
-
--   \`yparam\`  
+-   [z][37]
+    -   [zMethod][38]
 
 ## Class
 
@@ -7104,31 +7094,15 @@ exports[`outputs document-exported.input.js markdown 1`] = `
 
 -   \`v\`  
 
-### staticMethod
-
-### staticGetter
-
 ### staticSetter
 
 #### Parameters
 
 -   \`v\`  
 
-## T5
+### staticMethod
 
-Type: [boolean][40]
-
-## y2Default
-
-## y4
-
-Description of y3
-
-### Parameters
-
--   \`p\` **[number][41]** 
-
-Returns **void** 
+### staticGetter
 
 ## object
 
@@ -7152,7 +7126,7 @@ Returns **void**
 
 ## T
 
-Type: [number][41]
+Type: [number][40]
 
 ## T2
 
@@ -7184,87 +7158,113 @@ f5 comment
 
 ### om2
 
-[1]: #z
+## T5
 
-[2]: #zmethod
+Type: [boolean][41]
 
-[3]: #x
+## x
 
-[4]: #parameters
+### Parameters
 
-[5]: #class
+-   \`yparam\`  
+
+## y2Default
+
+## y4
+
+Description of y3
+
+### Parameters
+
+-   \`p\` **[number][40]** 
+
+Returns **void** 
+
+## z
+
+### zMethod
+
+[1]: #class
+
+[2]: #parameters
+
+[3]: #classmethod
+
+[4]: #classgetter
+
+[5]: #classsetter
 
 [6]: #parameters-1
 
-[7]: #classmethod
+[7]: #staticsetter
 
-[8]: #classgetter
+[8]: #parameters-2
 
-[9]: #classsetter
+[9]: #staticmethod
 
-[10]: #parameters-2
+[10]: #staticgetter
 
-[11]: #staticmethod
+[11]: #object
 
-[12]: #staticgetter
+[12]: #method
 
-[13]: #staticsetter
+[13]: #getter
 
-[14]: #parameters-3
+[14]: #setter
 
-[15]: #t5
+[15]: #parameters-3
 
-[16]: #y2default
+[16]: #prop
 
-[17]: #y4
+[17]: #func
 
-[18]: #parameters-4
+[18]: #f1
 
-[19]: #object
+[19]: #f3
 
-[20]: #method
+[20]: #t
 
-[21]: #getter
+[21]: #t2
 
-[22]: #setter
+[22]: #t4
 
-[23]: #parameters-5
+[23]: #f4
 
-[24]: #prop
+[24]: #parameters-4
 
-[25]: #func
+[25]: #o1
 
-[26]: #f1
+[26]: #om1
 
-[27]: #f3
+[27]: #f5
 
-[28]: #t
+[28]: #parameters-5
 
-[29]: #t2
+[29]: #o2
 
-[30]: #t4
+[30]: #om2
 
-[31]: #f4
+[31]: #t5
 
-[32]: #parameters-6
+[32]: #x
 
-[33]: #o1
+[33]: #parameters-6
 
-[34]: #om1
+[34]: #y2default
 
-[35]: #f5
+[35]: #y4
 
 [36]: #parameters-7
 
-[37]: #o2
+[37]: #z
 
-[38]: #om2
+[38]: #zmethod
 
 [39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[40]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[40]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[41]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[41]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 "
 `;
 
@@ -7274,74 +7274,6 @@ Object {
     Object {
       "type": "html",
       "value": "<!-- Generated by documentation.js. Update this documentation by updating the source code. -->",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "z",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "zMethod",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "x",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Parameters",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "yparam",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
-        },
-      ],
-      "ordered": false,
-      "type": "list",
     },
     Object {
       "children": Array [
@@ -7479,26 +7411,6 @@ Object {
       "children": Array [
         Object {
           "type": "text",
-          "value": "staticMethod",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "staticGetter",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
           "value": "staticSetter",
         },
       ],
@@ -7547,92 +7459,7 @@ Object {
       "children": Array [
         Object {
           "type": "text",
-          "value": "T5",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Type: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "boolean",
-            },
-          ],
-          "identifier": "2",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-      ],
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "y2Default",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "y4",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 18,
-              "line": 1,
-              "offset": 17,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "Description of y3",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 18,
-          "line": 1,
-          "offset": 17,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Parameters",
+          "value": "staticMethod",
         },
       ],
       "depth": 3,
@@ -7641,68 +7468,12 @@ Object {
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "p",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "text",
-                          "value": "number",
-                        },
-                      ],
-                      "identifier": "3",
-                      "referenceType": "full",
-                      "type": "linkReference",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
+          "type": "text",
+          "value": "staticGetter",
         },
       ],
-      "ordered": false,
-      "type": "list",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Returns ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "void",
-            },
-          ],
-          "type": "strong",
-        },
-        Object {
-          "type": "text",
-          "value": " ",
-        },
-      ],
-      "type": "paragraph",
+      "depth": 3,
+      "type": "heading",
     },
     Object {
       "children": Array [
@@ -7845,7 +7616,7 @@ Object {
               "value": "number",
             },
           ],
-          "identifier": "3",
+          "identifier": "2",
           "referenceType": "full",
           "type": "linkReference",
         },
@@ -8102,6 +7873,235 @@ Object {
       "type": "heading",
     },
     Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "T5",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Type: ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "boolean",
+            },
+          ],
+          "identifier": "3",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "x",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Parameters",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "yparam",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "y2Default",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "y4",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "Description of y3",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+          "offset": 17,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Parameters",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "p",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "text",
+                          "value": "number",
+                        },
+                      ],
+                      "identifier": "2",
+                      "referenceType": "full",
+                      "type": "linkReference",
+                    },
+                  ],
+                  "type": "strong",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Returns ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "void",
+            },
+          ],
+          "type": "strong",
+        },
+        Object {
+          "type": "text",
+          "value": " ",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "z",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "zMethod",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
       "identifier": "1",
       "title": undefined,
       "type": "definition",
@@ -8111,13 +8111,13 @@ Object {
       "identifier": "2",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
     },
     Object {
       "identifier": "3",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
     },
   ],
   "type": "root",
@@ -8661,6 +8661,1126 @@ have any parameter descriptions.",
         "title": "example",
       },
     ],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "async": true,
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 114,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 114,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 24,
+                  "line": 1,
+                  "offset": 23,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This is an async method",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 24,
+          "line": 1,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 113,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 111,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "foo",
+    "namespace": "foo",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "foo",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 122,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 122,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 38,
+                  "line": 1,
+                  "offset": 37,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This function returns the number one.",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 38,
+              "line": 1,
+              "offset": 37,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 38,
+          "line": 1,
+          "offset": 37,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 121,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 118,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "es6.input",
+    "namespace": "es6.input",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "es6.input",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [
+      Object {
+        "description": Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 10,
+                      "line": 1,
+                      "offset": 9,
+                    },
+                    "indent": Array [],
+                    "start": Object {
+                      "column": 1,
+                      "line": 1,
+                      "offset": 0,
+                    },
+                  },
+                  "type": "text",
+                  "value": "numberone",
+                },
+              ],
+              "position": Object {
+                "end": Object {
+                  "column": 10,
+                  "line": 1,
+                  "offset": 9,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 10,
+              "line": 1,
+              "offset": 9,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "root",
+        },
+        "title": "returns",
+        "type": Object {
+          "name": "Number",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "sees": Array [],
+    "tags": Array [
+      Object {
+        "description": "numberone",
+        "lineNumber": 2,
+        "title": "returns",
+        "type": Object {
+          "name": "Number",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 129,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 127,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 53,
+                  "line": 1,
+                  "offset": 52,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This tests our support of optional parameters in ES6",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 53,
+              "line": 1,
+              "offset": 52,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 53,
+          "line": 1,
+          "offset": 52,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 126,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 124,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "veryImportantTransform",
+    "namespace": "veryImportantTransform",
+    "params": Array [
+      Object {
+        "default": "'bar'",
+        "lineNumber": 127,
+        "name": "foo",
+        "title": "param",
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "veryImportantTransform",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "access": "protected",
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 26,
+          "line": 143,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 143,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 21,
+                  "line": 1,
+                  "offset": 20,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "A protected function",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+          "offset": 20,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 142,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 139,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "iAmProtected",
+    "namespace": "iAmProtected",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "iAmProtected",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [
+      Object {
+        "description": null,
+        "lineNumber": 2,
+        "title": "protected",
+      },
+    ],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "access": "public",
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 149,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 149,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 1,
+                  "offset": 17,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "A public function",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+          "offset": 17,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 148,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 145,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "iAmPublic",
+    "namespace": "iAmPublic",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "iAmPublic",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [
+      Object {
+        "description": null,
+        "lineNumber": 2,
+        "title": "public",
+      },
+    ],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 42,
+          "line": 160,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 160,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 20,
+                  "line": 1,
+                  "offset": 19,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This is re-exported",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 20,
+              "line": 1,
+              "offset": 19,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 20,
+          "line": 1,
+          "offset": 19,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 159,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 157,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "execute",
+    "namespace": "execute",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "name": "execute",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 169,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 163,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 26,
+                  "line": 1,
+                  "offset": 25,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "Regression check for #498",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 26,
+          "line": 1,
+          "offset": 25,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 32,
+        "line": 162,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 162,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "isArrayEqualWith",
+    "namespace": "isArrayEqualWith",
+    "params": Array [
+      Object {
+        "lineNumber": 164,
+        "name": "array1",
+        "title": "param",
+        "type": Object {
+          "applications": Array [
+            Object {
+              "name": "T",
+              "type": "NameExpression",
+            },
+          ],
+          "expression": Object {
+            "name": "Array",
+            "type": "NameExpression",
+          },
+          "type": "TypeApplication",
+        },
+      },
+      Object {
+        "lineNumber": 165,
+        "name": "array2",
+        "title": "param",
+        "type": Object {
+          "applications": Array [
+            Object {
+              "name": "T",
+              "type": "NameExpression",
+            },
+          ],
+          "expression": Object {
+            "name": "Array",
+            "type": "NameExpression",
+          },
+          "type": "TypeApplication",
+        },
+      },
+      Object {
+        "default": "(a:T,b:T):boolean=>a===b",
+        "lineNumber": 166,
+        "name": "compareFunction",
+        "title": "param",
+        "type": Object {
+          "params": Array [
+            Object {
+              "expression": Object {
+                "name": "T",
+                "type": "NameExpression",
+              },
+              "name": "a",
+              "type": "ParameterType",
+            },
+            Object {
+              "expression": Object {
+                "name": "T",
+                "type": "NameExpression",
+              },
+              "name": "b",
+              "type": "ParameterType",
+            },
+          ],
+          "result": Object {
+            "name": "boolean",
+            "type": "NameExpression",
+          },
+          "type": "FunctionType",
+        },
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "isArrayEqualWith",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [
+      Object {
+        "title": "returns",
+        "type": Object {
+          "name": "boolean",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 174,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 172,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 26,
+                  "line": 1,
+                  "offset": 25,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "Regression check for #749",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 26,
+          "line": 1,
+          "offset": 25,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 32,
+        "line": 171,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 171,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "paramWithMemberType",
+    "namespace": "paramWithMemberType",
+    "params": Array [
+      Object {
+        "lineNumber": 172,
+        "name": "a",
+        "title": "param",
+        "type": Object {
+          "name": "atype.property",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "paramWithMemberType",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [
+      Object {
+        "title": "returns",
+        "type": Object {
+          "name": "boolean",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 189,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 177,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 21,
+                  "line": 1,
+                  "offset": 20,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "babel parser plugins",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+          "offset": 20,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "class",
+    "loc": Object {
+      "end": Object {
+        "column": 27,
+        "line": 176,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 176,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "A",
+    "namespace": "A",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "class",
+        "name": "A",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
     "throws": Array [],
     "todos": Array [],
     "yields": Array [],
@@ -10446,1126 +11566,6 @@ It takes a ",
     "todos": Array [],
     "yields": Array [],
   },
-  Object {
-    "async": true,
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 23,
-          "line": 114,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 114,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 24,
-                  "line": 1,
-                  "offset": 23,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This is an async method",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 24,
-              "line": 1,
-              "offset": 23,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 24,
-          "line": 1,
-          "offset": 23,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 113,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 111,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "foo",
-    "namespace": "foo",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "foo",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 36,
-          "line": 122,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 122,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 38,
-                  "line": 1,
-                  "offset": 37,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This function returns the number one.",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 38,
-              "line": 1,
-              "offset": 37,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 38,
-          "line": 1,
-          "offset": 37,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 121,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 118,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "es6.input",
-    "namespace": "es6.input",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "es6.input",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [
-      Object {
-        "description": Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "end": Object {
-                      "column": 10,
-                      "line": 1,
-                      "offset": 9,
-                    },
-                    "indent": Array [],
-                    "start": Object {
-                      "column": 1,
-                      "line": 1,
-                      "offset": 0,
-                    },
-                  },
-                  "type": "text",
-                  "value": "numberone",
-                },
-              ],
-              "position": Object {
-                "end": Object {
-                  "column": 10,
-                  "line": 1,
-                  "offset": 9,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "paragraph",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 10,
-              "line": 1,
-              "offset": 9,
-            },
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "root",
-        },
-        "title": "returns",
-        "type": Object {
-          "name": "Number",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "sees": Array [],
-    "tags": Array [
-      Object {
-        "description": "numberone",
-        "lineNumber": 2,
-        "title": "returns",
-        "type": Object {
-          "name": "Number",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 1,
-          "line": 129,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 127,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 53,
-                  "line": 1,
-                  "offset": 52,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This tests our support of optional parameters in ES6",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 53,
-              "line": 1,
-              "offset": 52,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 53,
-          "line": 1,
-          "offset": 52,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 126,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 124,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "veryImportantTransform",
-    "namespace": "veryImportantTransform",
-    "params": Array [
-      Object {
-        "default": "'bar'",
-        "lineNumber": 127,
-        "name": "foo",
-        "title": "param",
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "veryImportantTransform",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "access": "protected",
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 26,
-          "line": 143,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 143,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 21,
-                  "line": 1,
-                  "offset": 20,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "A protected function",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 21,
-              "line": 1,
-              "offset": 20,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 21,
-          "line": 1,
-          "offset": 20,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 142,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 139,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "iAmProtected",
-    "namespace": "iAmProtected",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "iAmProtected",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [
-      Object {
-        "description": null,
-        "lineNumber": 2,
-        "title": "protected",
-      },
-    ],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "access": "public",
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 23,
-          "line": 149,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 149,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 18,
-                  "line": 1,
-                  "offset": 17,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "A public function",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 18,
-              "line": 1,
-              "offset": 17,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 18,
-          "line": 1,
-          "offset": 17,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 148,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 145,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "iAmPublic",
-    "namespace": "iAmPublic",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "iAmPublic",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [
-      Object {
-        "description": null,
-        "lineNumber": 2,
-        "title": "public",
-      },
-    ],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 42,
-          "line": 160,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 160,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 20,
-                  "line": 1,
-                  "offset": 19,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This is re-exported",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 20,
-              "line": 1,
-              "offset": 19,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 20,
-          "line": 1,
-          "offset": 19,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 159,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 157,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "execute",
-    "namespace": "execute",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "name": "execute",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 1,
-          "line": 169,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 163,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 26,
-                  "line": 1,
-                  "offset": 25,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "Regression check for #498",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 26,
-              "line": 1,
-              "offset": 25,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 26,
-          "line": 1,
-          "offset": 25,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 32,
-        "line": 162,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 162,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "isArrayEqualWith",
-    "namespace": "isArrayEqualWith",
-    "params": Array [
-      Object {
-        "lineNumber": 164,
-        "name": "array1",
-        "title": "param",
-        "type": Object {
-          "applications": Array [
-            Object {
-              "name": "T",
-              "type": "NameExpression",
-            },
-          ],
-          "expression": Object {
-            "name": "Array",
-            "type": "NameExpression",
-          },
-          "type": "TypeApplication",
-        },
-      },
-      Object {
-        "lineNumber": 165,
-        "name": "array2",
-        "title": "param",
-        "type": Object {
-          "applications": Array [
-            Object {
-              "name": "T",
-              "type": "NameExpression",
-            },
-          ],
-          "expression": Object {
-            "name": "Array",
-            "type": "NameExpression",
-          },
-          "type": "TypeApplication",
-        },
-      },
-      Object {
-        "default": "(a:T,b:T):boolean=>a===b",
-        "lineNumber": 166,
-        "name": "compareFunction",
-        "title": "param",
-        "type": Object {
-          "params": Array [
-            Object {
-              "expression": Object {
-                "name": "T",
-                "type": "NameExpression",
-              },
-              "name": "a",
-              "type": "ParameterType",
-            },
-            Object {
-              "expression": Object {
-                "name": "T",
-                "type": "NameExpression",
-              },
-              "name": "b",
-              "type": "ParameterType",
-            },
-          ],
-          "result": Object {
-            "name": "boolean",
-            "type": "NameExpression",
-          },
-          "type": "FunctionType",
-        },
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "isArrayEqualWith",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [
-      Object {
-        "title": "returns",
-        "type": Object {
-          "name": "boolean",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 1,
-          "line": 174,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 172,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 26,
-                  "line": 1,
-                  "offset": 25,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "Regression check for #749",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 26,
-              "line": 1,
-              "offset": 25,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 26,
-          "line": 1,
-          "offset": 25,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 32,
-        "line": 171,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 171,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "paramWithMemberType",
-    "namespace": "paramWithMemberType",
-    "params": Array [
-      Object {
-        "lineNumber": 172,
-        "name": "a",
-        "title": "param",
-        "type": Object {
-          "name": "atype.property",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "paramWithMemberType",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [
-      Object {
-        "title": "returns",
-        "type": Object {
-          "name": "boolean",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 1,
-          "line": 189,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 177,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 21,
-                  "line": 1,
-                  "offset": 20,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "babel parser plugins",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 21,
-              "line": 1,
-              "offset": 20,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 21,
-          "line": 1,
-          "offset": 20,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "class",
-    "loc": Object {
-      "end": Object {
-        "column": 27,
-        "line": 176,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 176,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "A",
-    "namespace": "A",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "class",
-        "name": "A",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
 ]
 `;
 
@@ -11579,35 +11579,35 @@ exports[`outputs es6.input.js markdown 1`] = `
 -   [destructure][3]
     -   [Parameters][4]
     -   [Examples][5]
--   [multiply][6]
-    -   [Parameters][7]
--   [Sink][8]
+-   [foo][6]
+-   [es6.input][7]
+-   [veryImportantTransform][8]
     -   [Parameters][9]
-    -   [Examples][10]
-    -   [staticProp][11]
-    -   [empty][12]
-    -   [classprop][13]
-        -   [Parameters][14]
-    -   [aGetter][15]
-    -   [hello][16]
--   [makeABasket][17]
--   [makeASink][18]
--   [functionWithRest][19]
-    -   [Parameters][20]
--   [functionWithRestAndType][21]
-    -   [Parameters][22]
--   [foo][23]
--   [es6.input][24]
--   [veryImportantTransform][25]
-    -   [Parameters][26]
--   [iAmProtected][27]
--   [iAmPublic][28]
--   [execute][29]
--   [isArrayEqualWith][30]
-    -   [Parameters][31]
--   [paramWithMemberType][32]
-    -   [Parameters][33]
--   [A][34]
+-   [iAmProtected][10]
+-   [iAmPublic][11]
+-   [execute][12]
+-   [isArrayEqualWith][13]
+    -   [Parameters][14]
+-   [paramWithMemberType][15]
+    -   [Parameters][16]
+-   [A][17]
+-   [multiply][18]
+    -   [Parameters][19]
+-   [Sink][20]
+    -   [Parameters][21]
+    -   [Examples][22]
+    -   [staticProp][23]
+    -   [empty][24]
+    -   [classprop][25]
+        -   [Parameters][26]
+    -   [aGetter][27]
+    -   [hello][28]
+-   [makeABasket][29]
+-   [makeASink][30]
+-   [functionWithRest][31]
+    -   [Parameters][32]
+-   [functionWithRestAndType][33]
+    -   [Parameters][34]
 
 ## destructure
 
@@ -11637,6 +11637,62 @@ Similar, but with an array
 \`\`\`javascript
 destructure([1, 2, 3])
 \`\`\`
+
+## foo
+
+This is an async method
+
+## es6.input
+
+This function returns the number one.
+
+Returns **[Number][37]** numberone
+
+## veryImportantTransform
+
+This tests our support of optional parameters in ES6
+
+### Parameters
+
+-   \`foo\`   (optional, default \`'bar'\`)
+
+## iAmProtected
+
+A protected function
+
+## iAmPublic
+
+A public function
+
+## execute
+
+This is re-exported
+
+## isArrayEqualWith
+
+Regression check for #498
+
+### Parameters
+
+-   \`array1\` **[Array][36]&lt;T>** 
+-   \`array2\` **[Array][36]&lt;T>** 
+-   \`compareFunction\` **function (a: T, b: T): [boolean][38]**  (optional, default \`(a:T,b:T):boolean=>a===b\`)
+
+Returns **[boolean][38]** 
+
+## paramWithMemberType
+
+Regression check for #749
+
+### Parameters
+
+-   \`a\` **atype.property** 
+
+Returns **[boolean][38]** 
+
+## A
+
+babel parser plugins
 
 ## multiply
 
@@ -11684,7 +11740,7 @@ This uses the class property transform
 
 -   \`a\` **[number][37]** 
 
-Returns **[string][38]** 
+Returns **[string][39]** 
 
 ### aGetter
 
@@ -11703,10 +11759,10 @@ Returns **Basket** a basket
 
 ## makeASink
 
-This method returns a [sink][8]. The type should be linked.
-It takes a [number][39] which should also be linked.
+This method returns a [sink][20]. The type should be linked.
+It takes a [number][40] which should also be linked.
 
-Returns **[Sink][40]** a sink
+Returns **[Sink][41]** a sink
 
 ## functionWithRest
 
@@ -11724,62 +11780,6 @@ So does this one, with types
 
 -   \`someParams\` **...[number][37]** 
 
-## foo
-
-This is an async method
-
-## es6.input
-
-This function returns the number one.
-
-Returns **[Number][37]** numberone
-
-## veryImportantTransform
-
-This tests our support of optional parameters in ES6
-
-### Parameters
-
--   \`foo\`   (optional, default \`'bar'\`)
-
-## iAmProtected
-
-A protected function
-
-## iAmPublic
-
-A public function
-
-## execute
-
-This is re-exported
-
-## isArrayEqualWith
-
-Regression check for #498
-
-### Parameters
-
--   \`array1\` **[Array][36]&lt;T>** 
--   \`array2\` **[Array][36]&lt;T>** 
--   \`compareFunction\` **function (a: T, b: T): [boolean][41]**  (optional, default \`(a:T,b:T):boolean=>a===b\`)
-
-Returns **[boolean][41]** 
-
-## paramWithMemberType
-
-Regression check for #749
-
-### Parameters
-
--   \`a\` **atype.property** 
-
-Returns **[boolean][41]** 
-
-## A
-
-babel parser plugins
-
 [1]: #destructure
 
 [2]: #parameters
@@ -11790,63 +11790,63 @@ babel parser plugins
 
 [5]: #examples
 
-[6]: #multiply
+[6]: #foo
 
-[7]: #parameters-2
+[7]: #es6input
 
-[8]: #sink
+[8]: #veryimportanttransform
 
-[9]: #parameters-3
+[9]: #parameters-2
 
-[10]: #examples-1
+[10]: #iamprotected
 
-[11]: #staticprop
+[11]: #iampublic
 
-[12]: #empty
+[12]: #execute
 
-[13]: #classprop
+[13]: #isarrayequalwith
 
-[14]: #parameters-4
+[14]: #parameters-3
 
-[15]: #agetter
+[15]: #paramwithmembertype
 
-[16]: #hello
+[16]: #parameters-4
 
-[17]: #makeabasket
+[17]: #a
 
-[18]: #makeasink
+[18]: #multiply
 
-[19]: #functionwithrest
+[19]: #parameters-5
 
-[20]: #parameters-5
+[20]: #sink
 
-[21]: #functionwithrestandtype
+[21]: #parameters-6
 
-[22]: #parameters-6
+[22]: #examples-1
 
-[23]: #foo
+[23]: #staticprop
 
-[24]: #es6input
+[24]: #empty
 
-[25]: #veryimportanttransform
+[25]: #classprop
 
 [26]: #parameters-7
 
-[27]: #iamprotected
+[27]: #agetter
 
-[28]: #iampublic
+[28]: #hello
 
-[29]: #execute
+[29]: #makeabasket
 
-[30]: #isarrayequalwith
+[30]: #makeasink
 
-[31]: #parameters-8
+[31]: #functionwithrest
 
-[32]: #paramwithmembertype
+[32]: #parameters-8
 
-[33]: #parameters-9
+[33]: #functionwithrestandtype
 
-[34]: #a
+[34]: #parameters-9
 
 [35]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
@@ -11854,13 +11854,13 @@ babel parser plugins
 
 [37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[38]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[38]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[40]: #sink
+[40]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[41]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[41]: #sink
 "
 `;
 
@@ -12296,6 +12296,838 @@ have any parameter descriptions.",
       "lang": "javascript",
       "type": "code",
       "value": "destructure([1, 2, 3])",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "foo",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This is an async method",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 24,
+          "line": 1,
+          "offset": 23,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "es6.input",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 38,
+              "line": 1,
+              "offset": 37,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This function returns the number one.",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 38,
+          "line": 1,
+          "offset": 37,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Returns ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Number",
+                },
+              ],
+              "identifier": "3",
+              "referenceType": "full",
+              "type": "linkReference",
+            },
+          ],
+          "type": "strong",
+        },
+        Object {
+          "type": "text",
+          "value": " ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 10,
+                  "line": 1,
+                  "offset": 9,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "numberone",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 10,
+              "line": 1,
+              "offset": 9,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "veryImportantTransform",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 53,
+              "line": 1,
+              "offset": 52,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This tests our support of optional parameters in ES6",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 53,
+          "line": 1,
+          "offset": 52,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Parameters",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "foo",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": " (optional, default ",
+                    },
+                    Object {
+                      "type": "inlineCode",
+                      "value": "'bar'",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": ")",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "iAmProtected",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "A protected function",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+          "offset": 20,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "iAmPublic",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "A public function",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+          "offset": 17,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "execute",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 1,
+              "offset": 19,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This is re-exported",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 20,
+          "line": 1,
+          "offset": 19,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "isArrayEqualWith",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "Regression check for #498",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 26,
+          "line": 1,
+          "offset": 25,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Parameters",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "array1",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "text",
+                          "value": "Array",
+                        },
+                      ],
+                      "identifier": "2",
+                      "referenceType": "full",
+                      "type": "linkReference",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "<",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "T",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": ">",
+                    },
+                  ],
+                  "type": "strong",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "array2",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "text",
+                          "value": "Array",
+                        },
+                      ],
+                      "identifier": "2",
+                      "referenceType": "full",
+                      "type": "linkReference",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "<",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "T",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": ">",
+                    },
+                  ],
+                  "type": "strong",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "compareFunction",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": "function (",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "a: ",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "T",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": ", ",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "b: ",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": "T",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": ")",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": ": ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "text",
+                          "value": "boolean",
+                        },
+                      ],
+                      "identifier": "4",
+                      "referenceType": "full",
+                      "type": "linkReference",
+                    },
+                  ],
+                  "type": "strong",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": " (optional, default ",
+                    },
+                    Object {
+                      "type": "inlineCode",
+                      "value": "(a:T,b:T):boolean=>a===b",
+                    },
+                    Object {
+                      "type": "text",
+                      "value": ")",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Returns ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "boolean",
+                },
+              ],
+              "identifier": "4",
+              "referenceType": "full",
+              "type": "linkReference",
+            },
+          ],
+          "type": "strong",
+        },
+        Object {
+          "type": "text",
+          "value": " ",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "paramWithMemberType",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "Regression check for #749",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 26,
+          "line": 1,
+          "offset": 25,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Parameters",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "a",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": "atype.property",
+                    },
+                  ],
+                  "type": "strong",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Returns ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "boolean",
+                },
+              ],
+              "identifier": "4",
+              "referenceType": "full",
+              "type": "linkReference",
+            },
+          ],
+          "type": "strong",
+        },
+        Object {
+          "type": "text",
+          "value": " ",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "A",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "babel parser plugins",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+          "offset": 20,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
     },
     Object {
       "children": Array [
@@ -12966,7 +13798,7 @@ class A {
                   "value": "string",
                 },
               ],
-              "identifier": "4",
+              "identifier": "5",
               "referenceType": "full",
               "type": "linkReference",
             },
@@ -13213,7 +14045,7 @@ as a property.",
               "value": "sink",
             },
           ],
-          "identifier": "5",
+          "identifier": "6",
           "referenceType": "full",
           "type": "linkReference",
         },
@@ -13244,7 +14076,7 @@ It takes a ",
               "value": "number",
             },
           ],
-          "identifier": "6",
+          "identifier": "7",
           "referenceType": "full",
           "type": "linkReference",
         },
@@ -13298,7 +14130,7 @@ It takes a ",
                   "value": "Sink",
                 },
               ],
-              "identifier": "7",
+              "identifier": "8",
               "referenceType": "full",
               "type": "linkReference",
             },
@@ -13547,838 +14379,6 @@ It takes a ",
       "type": "list",
     },
     Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "foo",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 24,
-              "line": 1,
-              "offset": 23,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "This is an async method",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 24,
-          "line": 1,
-          "offset": 23,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "es6.input",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 1,
-              "offset": 37,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "This function returns the number one.",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 38,
-          "line": 1,
-          "offset": 37,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Returns ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "Number",
-                },
-              ],
-              "identifier": "3",
-              "referenceType": "full",
-              "type": "linkReference",
-            },
-          ],
-          "type": "strong",
-        },
-        Object {
-          "type": "text",
-          "value": " ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 10,
-                  "line": 1,
-                  "offset": 9,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "numberone",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 10,
-              "line": 1,
-              "offset": 9,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "veryImportantTransform",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 53,
-              "line": 1,
-              "offset": 52,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "This tests our support of optional parameters in ES6",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 53,
-          "line": 1,
-          "offset": 52,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Parameters",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "foo",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "type": "text",
-                      "value": " (optional, default ",
-                    },
-                    Object {
-                      "type": "inlineCode",
-                      "value": "'bar'",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": ")",
-                    },
-                  ],
-                  "type": "paragraph",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
-        },
-      ],
-      "ordered": false,
-      "type": "list",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "iAmProtected",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 21,
-              "line": 1,
-              "offset": 20,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "A protected function",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 21,
-          "line": 1,
-          "offset": 20,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "iAmPublic",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 18,
-              "line": 1,
-              "offset": 17,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "A public function",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 18,
-          "line": 1,
-          "offset": 17,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "execute",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1,
-              "offset": 19,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "This is re-exported",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 20,
-          "line": 1,
-          "offset": 19,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "isArrayEqualWith",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 26,
-              "line": 1,
-              "offset": 25,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "Regression check for #498",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 26,
-          "line": 1,
-          "offset": 25,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Parameters",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "array1",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "text",
-                          "value": "Array",
-                        },
-                      ],
-                      "identifier": "2",
-                      "referenceType": "full",
-                      "type": "linkReference",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "<",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "T",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": ">",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "array2",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "text",
-                          "value": "Array",
-                        },
-                      ],
-                      "identifier": "2",
-                      "referenceType": "full",
-                      "type": "linkReference",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "<",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "T",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": ">",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "compareFunction",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "type": "text",
-                      "value": "function (",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "a: ",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "T",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": ", ",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "b: ",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": "T",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": ")",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": ": ",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "text",
-                          "value": "boolean",
-                        },
-                      ],
-                      "identifier": "8",
-                      "referenceType": "full",
-                      "type": "linkReference",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "type": "text",
-                      "value": " (optional, default ",
-                    },
-                    Object {
-                      "type": "inlineCode",
-                      "value": "(a:T,b:T):boolean=>a===b",
-                    },
-                    Object {
-                      "type": "text",
-                      "value": ")",
-                    },
-                  ],
-                  "type": "paragraph",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
-        },
-      ],
-      "ordered": false,
-      "type": "list",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Returns ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "boolean",
-                },
-              ],
-              "identifier": "8",
-              "referenceType": "full",
-              "type": "linkReference",
-            },
-          ],
-          "type": "strong",
-        },
-        Object {
-          "type": "text",
-          "value": " ",
-        },
-      ],
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "paramWithMemberType",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 26,
-              "line": 1,
-              "offset": 25,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "Regression check for #749",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 26,
-          "line": 1,
-          "offset": 25,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Parameters",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "a",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "type": "text",
-                      "value": "atype.property",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
-        },
-      ],
-      "ordered": false,
-      "type": "list",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Returns ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "boolean",
-                },
-              ],
-              "identifier": "8",
-              "referenceType": "full",
-              "type": "linkReference",
-            },
-          ],
-          "type": "strong",
-        },
-        Object {
-          "type": "text",
-          "value": " ",
-        },
-      ],
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "A",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 21,
-              "line": 1,
-              "offset": 20,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "babel parser plugins",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 21,
-          "line": 1,
-          "offset": 20,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
       "identifier": "1",
       "title": undefined,
       "type": "definition",
@@ -14400,31 +14400,31 @@ It takes a ",
       "identifier": "4",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
     },
     Object {
       "identifier": "5",
-      "title": null,
+      "title": undefined,
       "type": "definition",
-      "url": "#sink",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
     },
     Object {
       "identifier": "6",
       "title": null,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
+      "url": "#sink",
     },
     Object {
       "identifier": "7",
-      "title": undefined,
+      "title": null,
       "type": "definition",
-      "url": "#sink",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
     },
     Object {
       "identifier": "8",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+      "url": "#sink",
     },
   ],
   "type": "root",
@@ -15495,131 +15495,6 @@ Array [
             "loc": Object {
               "end": Object {
                 "column": 3,
-                "line": 11,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 9,
-              },
-            },
-          },
-          "description": Object {
-            "children": Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "position": Object {
-                      "end": Object {
-                        "column": 31,
-                        "line": 1,
-                        "offset": 30,
-                      },
-                      "indent": Array [],
-                      "start": Object {
-                        "column": 1,
-                        "line": 1,
-                        "offset": 0,
-                      },
-                    },
-                    "type": "text",
-                    "value": "This is a read-write property.",
-                  },
-                ],
-                "position": Object {
-                  "end": Object {
-                    "column": 31,
-                    "line": 1,
-                    "offset": 30,
-                  },
-                  "indent": Array [],
-                  "start": Object {
-                    "column": 1,
-                    "line": 1,
-                    "offset": 0,
-                  },
-                },
-                "type": "paragraph",
-              },
-            ],
-            "position": Object {
-              "end": Object {
-                "column": 31,
-                "line": 1,
-                "offset": 30,
-              },
-              "start": Object {
-                "column": 1,
-                "line": 1,
-                "offset": 0,
-              },
-            },
-            "type": "root",
-          },
-          "errors": Array [],
-          "examples": Array [],
-          "implements": Array [],
-          "kind": "member",
-          "loc": Object {
-            "end": Object {
-              "column": 5,
-              "line": 8,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 5,
-            },
-          },
-          "memberof": "Issue906",
-          "members": Object {
-            "events": Array [],
-            "global": Array [],
-            "inner": Array [],
-            "instance": Array [],
-            "static": Array [],
-          },
-          "name": "readWriteProp",
-          "namespace": "Issue906#readWriteProp",
-          "params": Array [],
-          "path": Array [
-            Object {
-              "kind": "class",
-              "name": "Issue906",
-            },
-            Object {
-              "kind": "member",
-              "name": "readWriteProp",
-              "scope": "instance",
-            },
-          ],
-          "properties": Array [],
-          "returns": Array [],
-          "scope": "instance",
-          "sees": Array [],
-          "tags": Array [
-            Object {
-              "description": null,
-              "lineNumber": 2,
-              "title": "type",
-              "type": Object {
-                "name": "boolean",
-                "type": "NameExpression",
-              },
-            },
-          ],
-          "throws": Array [],
-          "todos": Array [],
-          "type": Object {
-            "name": "boolean",
-            "type": "NameExpression",
-          },
-          "yields": Array [],
-        },
-        Object {
-          "augments": Array [],
-          "context": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 3,
                 "line": 24,
               },
               "start": Object {
@@ -15745,6 +15620,131 @@ Array [
           },
           "yields": Array [],
         },
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 3,
+                "line": 11,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 9,
+              },
+            },
+          },
+          "description": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "end": Object {
+                        "column": 31,
+                        "line": 1,
+                        "offset": 30,
+                      },
+                      "indent": Array [],
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                        "offset": 0,
+                      },
+                    },
+                    "type": "text",
+                    "value": "This is a read-write property.",
+                  },
+                ],
+                "position": Object {
+                  "end": Object {
+                    "column": 31,
+                    "line": 1,
+                    "offset": 30,
+                  },
+                  "indent": Array [],
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "position": Object {
+              "end": Object {
+                "column": 31,
+                "line": 1,
+                "offset": 30,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "type": "root",
+          },
+          "errors": Array [],
+          "examples": Array [],
+          "implements": Array [],
+          "kind": "member",
+          "loc": Object {
+            "end": Object {
+              "column": 5,
+              "line": 8,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 5,
+            },
+          },
+          "memberof": "Issue906",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "readWriteProp",
+          "namespace": "Issue906#readWriteProp",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": "class",
+              "name": "Issue906",
+            },
+            Object {
+              "kind": "member",
+              "name": "readWriteProp",
+              "scope": "instance",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "instance",
+          "sees": Array [],
+          "tags": Array [
+            Object {
+              "description": null,
+              "lineNumber": 2,
+              "title": "type",
+              "type": Object {
+                "name": "boolean",
+                "type": "NameExpression",
+              },
+            },
+          ],
+          "throws": Array [],
+          "todos": Array [],
+          "type": Object {
+            "name": "boolean",
+            "type": "NameExpression",
+          },
+          "yields": Array [],
+        },
       ],
       "static": Array [],
     },
@@ -15774,34 +15774,34 @@ exports[`outputs es6-class-property.input.js markdown 1`] = `
 ### Table of Contents
 
 -   [Issue906][1]
-    -   [readWriteProp][2]
-    -   [readOnlyProp][3]
+    -   [readOnlyProp][2]
+    -   [readWriteProp][3]
 
 ## Issue906
 
 This is for issue 906.
 
-### readWriteProp
-
-This is a read-write property.
-
-Type: [boolean][4]
-
 ### readOnlyProp
 
 This is a read-only property.
 
-Type: [string][5]
+Type: [string][4]
+
+### readWriteProp
+
+This is a read-write property.
+
+Type: [boolean][5]
 
 [1]: #issue906
 
-[2]: #readwriteprop
+[2]: #readonlyprop
 
-[3]: #readonlyprop
+[3]: #readwriteprop
 
-[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 "
 `;
 
@@ -15855,71 +15855,6 @@ Object {
           "offset": 0,
         },
       },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "readWriteProp",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 31,
-              "line": 1,
-              "offset": 30,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "This is a read-write property.",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 31,
-          "line": 1,
-          "offset": 30,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Type: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "boolean",
-            },
-          ],
-          "identifier": "1",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-      ],
       "type": "paragraph",
     },
     Object {
@@ -15980,6 +15915,71 @@ Object {
               "value": "string",
             },
           ],
+          "identifier": "1",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "readWriteProp",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 31,
+              "line": 1,
+              "offset": 30,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This is a read-write property.",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 31,
+          "line": 1,
+          "offset": 30,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Type: ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "boolean",
+            },
+          ],
           "identifier": "2",
           "referenceType": "full",
           "type": "linkReference",
@@ -15991,13 +15991,13 @@ Object {
       "identifier": "1",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
     },
     Object {
       "identifier": "2",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
     },
   ],
   "type": "root",
@@ -16157,6 +16157,108 @@ Object {
 
 exports[`outputs es6-import.input.js JSON 1`] = `
 Array [
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 4,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 34,
+                  "line": 1,
+                  "offset": 33,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This is the default export frogs!",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 34,
+              "line": 1,
+              "offset": 33,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+          "offset": 33,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "es6-ext",
+    "namespace": "es6-ext",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "name": "es6-ext",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
   Object {
     "augments": Array [],
     "context": Object {
@@ -16333,108 +16435,6 @@ Array [
         },
       },
     ],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 18,
-          "line": 4,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 4,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 34,
-                  "line": 1,
-                  "offset": 33,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This is the default export frogs!",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 34,
-              "line": 1,
-              "offset": 33,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 34,
-          "line": 1,
-          "offset": 33,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "es6-ext",
-    "namespace": "es6-ext",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "name": "es6-ext",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
     "throws": Array [],
     "todos": Array [],
     "yields": Array [],
@@ -16621,10 +16621,14 @@ exports[`outputs es6-import.input.js markdown 1`] = `
 
 ### Table of Contents
 
--   [multiplyTwice][1]
-    -   [Parameters][2]
--   [es6-ext][3]
+-   [es6-ext][1]
+-   [multiplyTwice][2]
+    -   [Parameters][3]
 -   [simple.input][4]
+
+## es6-ext
+
+This is the default export frogs!
 
 ## multiplyTwice
 
@@ -16636,21 +16640,17 @@ This function returns the number one.
 
 Returns **[Number][5]** numberone
 
-## es6-ext
-
-This is the default export frogs!
-
 ## simple.input
 
 This function returns the number one.
 
 Returns **[number][5]** numberone
 
-[1]: #multiplytwice
+[1]: #es6-ext
 
-[2]: #parameters
+[2]: #multiplytwice
 
-[3]: #es6-ext
+[3]: #parameters
 
 [4]: #simpleinput
 
@@ -16664,6 +16664,51 @@ Object {
     Object {
       "type": "html",
       "value": "<!-- Generated by documentation.js. Update this documentation by updating the source code. -->",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "es6-ext",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 34,
+              "line": 1,
+              "offset": 33,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This is the default export frogs!",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+          "offset": 33,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
     },
     Object {
       "children": Array [
@@ -16810,51 +16855,6 @@ Object {
           "type": "paragraph",
         },
       ],
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "es6-ext",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 34,
-              "line": 1,
-              "offset": 33,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "This is the default export frogs!",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 34,
-          "line": 1,
-          "offset": 33,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
       "type": "paragraph",
     },
     Object {
@@ -19052,264 +19052,6 @@ Array [
     "context": Object {
       "loc": Object {
         "end": Object {
-          "column": 25,
-          "line": 7,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 7,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 3,
-                  "line": 1,
-                  "offset": 2,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "x2",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 3,
-              "line": 1,
-              "offset": 2,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 3,
-          "line": 1,
-          "offset": 2,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "loc": Object {
-      "end": Object {
-        "column": 9,
-        "line": 6,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 6,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "x2",
-    "namespace": "x2",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "name": "x2",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "type": Object {
-      "params": Array [
-        Object {
-          "expression": Object {
-            "name": "T",
-            "type": "NameExpression",
-          },
-          "name": "a",
-          "type": "ParameterType",
-        },
-      ],
-      "result": Object {
-        "name": "string",
-        "type": "NameExpression",
-      },
-      "type": "FunctionType",
-    },
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 39,
-          "line": 10,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 10,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 2,
-                  "line": 1,
-                  "offset": 1,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "T",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 2,
-              "line": 1,
-              "offset": 1,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 2,
-          "line": 1,
-          "offset": 1,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "typedef",
-    "loc": Object {
-      "end": Object {
-        "column": 8,
-        "line": 9,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 9,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "T",
-    "namespace": "T",
-    "params": Array [],
-    "path": Array [
-      Object {
-        "kind": "typedef",
-        "name": "T",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "type": Object {
-      "params": Array [
-        Object {
-          "expression": Object {
-            "applications": Array [
-              Object {
-                "name": "string",
-                "type": "NameExpression",
-              },
-            ],
-            "expression": Object {
-              "name": "Array",
-              "type": "NameExpression",
-            },
-            "type": "TypeApplication",
-          },
-          "name": "",
-          "type": "ParameterType",
-        },
-      ],
-      "result": Object {
-        "fields": Array [
-          Object {
-            "key": "num",
-            "type": "FieldType",
-            "value": Object {
-              "name": "number",
-              "type": "NameExpression",
-            },
-          },
-        ],
-        "type": "RecordType",
-      },
-      "type": "FunctionType",
-    },
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
           "column": 43,
           "line": 13,
         },
@@ -19574,6 +19316,264 @@ Array [
     },
     "yields": Array [],
   },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 7,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "x2",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "loc": Object {
+      "end": Object {
+        "column": 9,
+        "line": 6,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 6,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "x2",
+    "namespace": "x2",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "name": "x2",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "type": Object {
+      "params": Array [
+        Object {
+          "expression": Object {
+            "name": "T",
+            "type": "NameExpression",
+          },
+          "name": "a",
+          "type": "ParameterType",
+        },
+      ],
+      "result": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+      "type": "FunctionType",
+    },
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 39,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 10,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 2,
+                  "line": 1,
+                  "offset": 1,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "T",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 1,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 2,
+          "line": 1,
+          "offset": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "typedef",
+    "loc": Object {
+      "end": Object {
+        "column": 8,
+        "line": 9,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 9,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "T",
+    "namespace": "T",
+    "params": Array [],
+    "path": Array [
+      Object {
+        "kind": "typedef",
+        "name": "T",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "type": Object {
+      "params": Array [
+        Object {
+          "expression": Object {
+            "applications": Array [
+              Object {
+                "name": "string",
+                "type": "NameExpression",
+              },
+            ],
+            "expression": Object {
+              "name": "Array",
+              "type": "NameExpression",
+            },
+            "type": "TypeApplication",
+          },
+          "name": "",
+          "type": "ParameterType",
+        },
+      ],
+      "result": Object {
+        "fields": Array [
+          Object {
+            "key": "num",
+            "type": "FieldType",
+            "value": Object {
+              "name": "number",
+              "type": "NameExpression",
+            },
+          },
+        ],
+        "type": "RecordType",
+      },
+      "type": "FunctionType",
+    },
+    "yields": Array [],
+  },
 ]
 `;
 
@@ -19582,50 +19582,50 @@ exports[`outputs flow-unnamed-params.input.js markdown 1`] = `
 
 ### Table of Contents
 
--   [x2][1]
--   [T][2]
--   [T2][3]
--   [T3][4]
-
-## x2
-
-x2
-
-Type: function (a: [T][5]): [string][6]
-
-## T
-
-T
-
-Type: function ([Array][7]&lt;[string][6]>): {num: [number][8]}
+-   [T2][1]
+-   [T3][2]
+-   [x2][3]
+-   [T][4]
 
 ## T2
 
 T2
 
-Type: function (a: [Array][7]&lt;[string][6]>): {num: [number][8]}
+Type: function (a: [Array][5]&lt;[string][6]>): {num: [number][7]}
 
 ## T3
 
 T3
 
-Type: function (a: [string][6]): {num: [number][8]}
+Type: function (a: [string][6]): {num: [number][7]}
 
-[1]: #x2
+## x2
 
-[2]: #t
+x2
 
-[3]: #t2
+Type: function (a: [T][8]): [string][6]
 
-[4]: #t3
+## T
 
-[5]: #t
+T
+
+Type: function ([Array][5]&lt;[string][6]>): {num: [number][7]}
+
+[1]: #t2
+
+[2]: #t3
+
+[3]: #x2
+
+[4]: #t
+
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
 [6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[8]: #t
 "
 `;
 
@@ -19635,6 +19635,233 @@ Object {
     Object {
       "type": "html",
       "value": "<!-- Generated by documentation.js. Update this documentation by updating the source code. -->",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "T2",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "T2",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Type: ",
+        },
+        Object {
+          "type": "text",
+          "value": "function (",
+        },
+        Object {
+          "type": "text",
+          "value": "a: ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "Array",
+            },
+          ],
+          "identifier": "1",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+        Object {
+          "type": "text",
+          "value": "<",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "string",
+            },
+          ],
+          "identifier": "2",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+        Object {
+          "type": "text",
+          "value": ">",
+        },
+        Object {
+          "type": "text",
+          "value": ")",
+        },
+        Object {
+          "type": "text",
+          "value": ": ",
+        },
+        Object {
+          "type": "text",
+          "value": "{",
+        },
+        Object {
+          "type": "text",
+          "value": "num: ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "number",
+            },
+          ],
+          "identifier": "3",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+        Object {
+          "type": "text",
+          "value": "}",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "T3",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "T3",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Type: ",
+        },
+        Object {
+          "type": "text",
+          "value": "function (",
+        },
+        Object {
+          "type": "text",
+          "value": "a: ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "string",
+            },
+          ],
+          "identifier": "2",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+        Object {
+          "type": "text",
+          "value": ")",
+        },
+        Object {
+          "type": "text",
+          "value": ": ",
+        },
+        Object {
+          "type": "text",
+          "value": "{",
+        },
+        Object {
+          "type": "text",
+          "value": "num: ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "number",
+            },
+          ],
+          "identifier": "3",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+        Object {
+          "type": "text",
+          "value": "}",
+        },
+      ],
+      "type": "paragraph",
     },
     Object {
       "children": Array [
@@ -19702,7 +19929,7 @@ Object {
               "value": "T",
             },
           ],
-          "identifier": "1",
+          "identifier": "4",
           "referenceType": "full",
           "type": "linkReference",
         },
@@ -19790,7 +20017,7 @@ Object {
               "value": "Array",
             },
           ],
-          "identifier": "3",
+          "identifier": "1",
           "referenceType": "full",
           "type": "linkReference",
         },
@@ -19836,234 +20063,7 @@ Object {
               "value": "number",
             },
           ],
-          "identifier": "4",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-        Object {
-          "type": "text",
-          "value": "}",
-        },
-      ],
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "T2",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 3,
-              "line": 1,
-              "offset": 2,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "T2",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 3,
-          "line": 1,
-          "offset": 2,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Type: ",
-        },
-        Object {
-          "type": "text",
-          "value": "function (",
-        },
-        Object {
-          "type": "text",
-          "value": "a: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "Array",
-            },
-          ],
           "identifier": "3",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-        Object {
-          "type": "text",
-          "value": "<",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "string",
-            },
-          ],
-          "identifier": "2",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-        Object {
-          "type": "text",
-          "value": ">",
-        },
-        Object {
-          "type": "text",
-          "value": ")",
-        },
-        Object {
-          "type": "text",
-          "value": ": ",
-        },
-        Object {
-          "type": "text",
-          "value": "{",
-        },
-        Object {
-          "type": "text",
-          "value": "num: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "number",
-            },
-          ],
-          "identifier": "4",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-        Object {
-          "type": "text",
-          "value": "}",
-        },
-      ],
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "T3",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 3,
-              "line": 1,
-              "offset": 2,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "T3",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 3,
-          "line": 1,
-          "offset": 2,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Type: ",
-        },
-        Object {
-          "type": "text",
-          "value": "function (",
-        },
-        Object {
-          "type": "text",
-          "value": "a: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "string",
-            },
-          ],
-          "identifier": "2",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-        Object {
-          "type": "text",
-          "value": ")",
-        },
-        Object {
-          "type": "text",
-          "value": ": ",
-        },
-        Object {
-          "type": "text",
-          "value": "{",
-        },
-        Object {
-          "type": "text",
-          "value": "num: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "number",
-            },
-          ],
-          "identifier": "4",
           "referenceType": "full",
           "type": "linkReference",
         },
@@ -20078,7 +20078,7 @@ Object {
       "identifier": "1",
       "title": undefined,
       "type": "definition",
-      "url": "#t",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
     },
     Object {
       "identifier": "2",
@@ -20090,13 +20090,13 @@ Object {
       "identifier": "3",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
+      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
     },
     Object {
       "identifier": "4",
       "title": undefined,
       "type": "definition",
-      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
+      "url": "#t",
     },
   ],
   "type": "root",
@@ -22972,115 +22972,6 @@ Array [
           "context": Object {
             "loc": Object {
               "end": Object {
-                "column": 20,
-                "line": 10,
-              },
-              "start": Object {
-                "column": 4,
-                "line": 10,
-              },
-            },
-          },
-          "description": Object {
-            "children": Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "position": Object {
-                      "end": Object {
-                        "column": 9,
-                        "line": 1,
-                        "offset": 8,
-                      },
-                      "indent": Array [],
-                      "start": Object {
-                        "column": 1,
-                        "line": 1,
-                        "offset": 0,
-                      },
-                    },
-                    "type": "text",
-                    "value": "My field",
-                  },
-                ],
-                "position": Object {
-                  "end": Object {
-                    "column": 9,
-                    "line": 1,
-                    "offset": 8,
-                  },
-                  "indent": Array [],
-                  "start": Object {
-                    "column": 1,
-                    "line": 1,
-                    "offset": 0,
-                  },
-                },
-                "type": "paragraph",
-              },
-            ],
-            "position": Object {
-              "end": Object {
-                "column": 9,
-                "line": 1,
-                "offset": 8,
-              },
-              "start": Object {
-                "column": 1,
-                "line": 1,
-                "offset": 0,
-              },
-            },
-            "type": "root",
-          },
-          "errors": Array [],
-          "examples": Array [],
-          "implements": Array [],
-          "loc": Object {
-            "end": Object {
-              "column": 19,
-              "line": 9,
-            },
-            "start": Object {
-              "column": 4,
-              "line": 9,
-            },
-          },
-          "memberof": "TheClass",
-          "members": Object {
-            "events": Array [],
-            "global": Array [],
-            "inner": Array [],
-            "instance": Array [],
-            "static": Array [],
-          },
-          "name": "my-field",
-          "namespace": "TheClass#my-field",
-          "params": Array [],
-          "path": Array [
-            Object {
-              "kind": "class",
-              "name": "TheClass",
-            },
-            Object {
-              "name": "my-field",
-              "scope": "instance",
-            },
-          ],
-          "properties": Array [],
-          "returns": Array [],
-          "scope": "instance",
-          "sees": Array [],
-          "tags": Array [],
-          "throws": Array [],
-          "todos": Array [],
-          "yields": Array [],
-        },
-        Object {
-          "augments": Array [],
-          "context": Object {
-            "loc": Object {
-              "end": Object {
                 "column": 5,
                 "line": 18,
               },
@@ -23582,6 +23473,115 @@ Array [
           "todos": Array [],
           "yields": Array [],
         },
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 20,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 10,
+              },
+            },
+          },
+          "description": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "end": Object {
+                        "column": 9,
+                        "line": 1,
+                        "offset": 8,
+                      },
+                      "indent": Array [],
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                        "offset": 0,
+                      },
+                    },
+                    "type": "text",
+                    "value": "My field",
+                  },
+                ],
+                "position": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 1,
+                    "offset": 8,
+                  },
+                  "indent": Array [],
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "position": Object {
+              "end": Object {
+                "column": 9,
+                "line": 1,
+                "offset": 8,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "type": "root",
+          },
+          "errors": Array [],
+          "examples": Array [],
+          "implements": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 9,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 9,
+            },
+          },
+          "memberof": "TheClass",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "my-field",
+          "namespace": "TheClass#my-field",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": "class",
+              "name": "TheClass",
+            },
+            Object {
+              "name": "my-field",
+              "scope": "instance",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "instance",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+          "yields": Array [],
+        },
       ],
       "static": Array [],
     },
@@ -23626,21 +23626,17 @@ exports[`outputs lends.input.js markdown 1`] = `
 ### Table of Contents
 
 -   [TheClass][1]
-    -   [my-field][2]
-    -   [foo][3]
-        -   [Parameters][4]
-    -   [bar][5]
-        -   [Parameters][6]
+    -   [foo][2]
+        -   [Parameters][3]
+    -   [bar][4]
+        -   [Parameters][5]
+    -   [my-field][6]
 
 ## TheClass
 
 **Extends Augmented**
 
 A neat layout view
-
-### my-field
-
-My field
 
 ### foo
 
@@ -23662,17 +23658,21 @@ My neat function
 
 Returns **[string][7]** your word but one better
 
+### my-field
+
+My field
+
 [1]: #theclass
 
-[2]: #my-field
+[2]: #foo
 
-[3]: #foo
+[3]: #parameters
 
-[4]: #parameters
+[4]: #bar
 
-[5]: #bar
+[5]: #parameters-1
 
-[6]: #parameters-1
+[6]: #my-field
 
 [7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 "
@@ -23738,51 +23738,6 @@ Object {
           "column": 19,
           "line": 1,
           "offset": 18,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "my-field",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 9,
-              "line": 1,
-              "offset": 8,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "My field",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 9,
-          "line": 1,
-          "offset": 8,
         },
         "indent": Array [],
         "start": Object {
@@ -24187,6 +24142,51 @@ Object {
           "type": "paragraph",
         },
       ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "my-field",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "My field",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+          "offset": 8,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "paragraph",
     },
     Object {
@@ -32109,209 +32109,6 @@ Array [
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 16,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 14,
-        },
-      },
-    },
-    "description": Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 42,
-                  "line": 1,
-                  "offset": 41,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "text",
-              "value": "This method has partially inferred params",
-            },
-          ],
-          "position": Object {
-            "end": Object {
-              "column": 42,
-              "line": 1,
-              "offset": 41,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "position": Object {
-        "end": Object {
-          "column": 42,
-          "line": 1,
-          "offset": 41,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "root",
-    },
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 13,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 9,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "fishesAndFoxes",
-    "namespace": "fishesAndFoxes",
-    "params": Array [
-      Object {
-        "lineNumber": 2,
-        "name": "options",
-        "properties": Array [
-          Object {
-            "description": Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "position": Object {
-                        "end": Object {
-                          "column": 24,
-                          "line": 1,
-                          "offset": 23,
-                        },
-                        "indent": Array [],
-                        "start": Object {
-                          "column": 1,
-                          "line": 1,
-                          "offset": 0,
-                        },
-                      },
-                      "type": "text",
-                      "value": "number of kinds of fish",
-                    },
-                  ],
-                  "position": Object {
-                    "end": Object {
-                      "column": 24,
-                      "line": 1,
-                      "offset": 23,
-                    },
-                    "indent": Array [],
-                    "start": Object {
-                      "column": 1,
-                      "line": 1,
-                      "offset": 0,
-                    },
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "position": Object {
-                "end": Object {
-                  "column": 24,
-                  "line": 1,
-                  "offset": 23,
-                },
-                "start": Object {
-                  "column": 1,
-                  "line": 1,
-                  "offset": 0,
-                },
-              },
-              "type": "root",
-            },
-            "lineNumber": 3,
-            "name": "options.fishes",
-            "title": "param",
-            "type": Object {
-              "name": "String",
-              "type": "NameExpression",
-            },
-          },
-          Object {
-            "lineNumber": 14,
-            "name": "options.foxes",
-            "title": "param",
-          },
-        ],
-        "title": "param",
-        "type": Object {
-          "name": "Object",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "fishesAndFoxes",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [
-      Object {
-        "description": null,
-        "lineNumber": 2,
-        "name": "options",
-        "title": "param",
-        "type": Object {
-          "name": "Object",
-          "type": "NameExpression",
-        },
-      },
-      Object {
-        "description": "number of kinds of fish",
-        "lineNumber": 3,
-        "name": "options.fishes",
-        "title": "param",
-        "type": Object {
-          "name": "String",
-          "type": "NameExpression",
-        },
-      },
-    ],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 1,
           "line": 24,
         },
         "start": Object {
@@ -34384,6 +34181,209 @@ or any type information we could infer from annotations.",
       "loc": Object {
         "end": Object {
           "column": 1,
+          "line": 16,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 14,
+        },
+      },
+    },
+    "description": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 42,
+                  "line": 1,
+                  "offset": 41,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "text",
+              "value": "This method has partially inferred params",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 42,
+              "line": 1,
+              "offset": 41,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 42,
+          "line": 1,
+          "offset": 41,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "root",
+    },
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 13,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 9,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "fishesAndFoxes",
+    "namespace": "fishesAndFoxes",
+    "params": Array [
+      Object {
+        "lineNumber": 2,
+        "name": "options",
+        "properties": Array [
+          Object {
+            "description": Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "end": Object {
+                          "column": 24,
+                          "line": 1,
+                          "offset": 23,
+                        },
+                        "indent": Array [],
+                        "start": Object {
+                          "column": 1,
+                          "line": 1,
+                          "offset": 0,
+                        },
+                      },
+                      "type": "text",
+                      "value": "number of kinds of fish",
+                    },
+                  ],
+                  "position": Object {
+                    "end": Object {
+                      "column": 24,
+                      "line": 1,
+                      "offset": 23,
+                    },
+                    "indent": Array [],
+                    "start": Object {
+                      "column": 1,
+                      "line": 1,
+                      "offset": 0,
+                    },
+                  },
+                  "type": "paragraph",
+                },
+              ],
+              "position": Object {
+                "end": Object {
+                  "column": 24,
+                  "line": 1,
+                  "offset": 23,
+                },
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "root",
+            },
+            "lineNumber": 3,
+            "name": "options.fishes",
+            "title": "param",
+            "type": Object {
+              "name": "String",
+              "type": "NameExpression",
+            },
+          },
+          Object {
+            "lineNumber": 14,
+            "name": "options.foxes",
+            "title": "param",
+          },
+        ],
+        "title": "param",
+        "type": Object {
+          "name": "Object",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "fishesAndFoxes",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [
+      Object {
+        "description": null,
+        "lineNumber": 2,
+        "name": "options",
+        "title": "param",
+        "type": Object {
+          "name": "Object",
+          "type": "NameExpression",
+        },
+      },
+      Object {
+        "description": "number of kinds of fish",
+        "lineNumber": 3,
+        "name": "options.fishes",
+        "title": "param",
+        "type": Object {
+          "name": "String",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
           "line": 111,
         },
         "start": Object {
@@ -34755,24 +34755,24 @@ exports[`outputs params.input.js markdown 1`] = `
 
 -   [addThem][1]
     -   [Parameters][2]
--   [fishesAndFoxes][3]
+-   [withDefault][3]
     -   [Parameters][4]
--   [withDefault][5]
-    -   [Parameters][6]
--   [Foo][7]
-    -   [method][8]
-        -   [Parameters][9]
--   [TraditionalObject][10]
-    -   [traditionalMethod][11]
-        -   [Parameters][12]
--   [Address6][13]
-    -   [Parameters][14]
-    -   [Examples][15]
--   [GeoJSONSource][16]
+-   [Foo][5]
+    -   [method][6]
+        -   [Parameters][7]
+-   [TraditionalObject][8]
+    -   [traditionalMethod][9]
+        -   [Parameters][10]
+-   [Address6][11]
+    -   [Parameters][12]
+    -   [Examples][13]
+-   [GeoJSONSource][14]
+    -   [Parameters][15]
+-   [myfunc][16]
     -   [Parameters][17]
--   [myfunc][18]
+-   [foo][18]
     -   [Parameters][19]
--   [foo][20]
+-   [fishesAndFoxes][20]
     -   [Parameters][21]
 -   [rotate][22]
     -   [Parameters][23]
@@ -34790,16 +34790,6 @@ This function returns the number one.
     -   \`$3.d\`  
     -   \`$3.e\`  
     -   \`$3.f\`  
-
-## fishesAndFoxes
-
-This method has partially inferred params
-
-### Parameters
-
--   \`options\` **[Object][25]** 
-    -   \`options.fishes\` **[String][26]** number of kinds of fish
-    -   \`options.foxes\`  
 
 ## withDefault
 
@@ -34887,6 +34877,16 @@ or any type information we could infer from annotations.
 
 -   \`address\`  An IPv6 address string
 
+## fishesAndFoxes
+
+This method has partially inferred params
+
+### Parameters
+
+-   \`options\` **[Object][25]** 
+    -   \`options.fishes\` **[String][26]** number of kinds of fish
+    -   \`options.foxes\`  
+
 ## rotate
 
 This tests our support for iterator rest inside an
@@ -34904,41 +34904,41 @@ Returns **[Array][27]&lt;any>** rotated such that the last element was the first
 
 [2]: #parameters
 
-[3]: #fishesandfoxes
+[3]: #withdefault
 
 [4]: #parameters-1
 
-[5]: #withdefault
+[5]: #foo
 
-[6]: #parameters-2
+[6]: #method
 
-[7]: #foo
+[7]: #parameters-2
 
-[8]: #method
+[8]: #traditionalobject
 
-[9]: #parameters-3
+[9]: #traditionalmethod
 
-[10]: #traditionalobject
+[10]: #parameters-3
 
-[11]: #traditionalmethod
+[11]: #address6
 
 [12]: #parameters-4
 
-[13]: #address6
+[13]: #examples
 
-[14]: #parameters-5
+[14]: #geojsonsource
 
-[15]: #examples
+[15]: #parameters-5
 
-[16]: #geojsonsource
+[16]: #myfunc
 
 [17]: #parameters-6
 
-[18]: #myfunc
+[18]: #foo-1
 
 [19]: #parameters-7
 
-[20]: #foo-1
+[20]: #fishesandfoxes
 
 [21]: #parameters-8
 
@@ -35225,206 +35225,6 @@ Object {
                         Object {
                           "type": "inlineCode",
                           "value": "$3.f",
-                        },
-                        Object {
-                          "type": "text",
-                          "value": " ",
-                        },
-                        Object {
-                          "type": "text",
-                          "value": " ",
-                        },
-                      ],
-                      "type": "paragraph",
-                    },
-                  ],
-                  "type": "listItem",
-                },
-              ],
-              "ordered": false,
-              "type": "list",
-            },
-          ],
-          "type": "listItem",
-        },
-      ],
-      "ordered": false,
-      "type": "list",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "fishesAndFoxes",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 1,
-              "offset": 41,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "This method has partially inferred params",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 42,
-          "line": 1,
-          "offset": 41,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Parameters",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "options",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "text",
-                          "value": "Object",
-                        },
-                      ],
-                      "identifier": "2",
-                      "referenceType": "full",
-                      "type": "linkReference",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "inlineCode",
-                          "value": "options.fishes",
-                        },
-                        Object {
-                          "type": "text",
-                          "value": " ",
-                        },
-                        Object {
-                          "children": Array [
-                            Object {
-                              "children": Array [
-                                Object {
-                                  "type": "text",
-                                  "value": "String",
-                                },
-                              ],
-                              "identifier": "3",
-                              "referenceType": "full",
-                              "type": "linkReference",
-                            },
-                          ],
-                          "type": "strong",
-                        },
-                        Object {
-                          "type": "text",
-                          "value": " ",
-                        },
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Position {
-                                "end": Object {
-                                  "column": 24,
-                                  "line": 1,
-                                  "offset": 23,
-                                },
-                                "indent": Array [],
-                                "start": Object {
-                                  "column": 1,
-                                  "line": 1,
-                                  "offset": 0,
-                                },
-                              },
-                              "type": "text",
-                              "value": "number of kinds of fish",
-                            },
-                          ],
-                          "position": Position {
-                            "end": Object {
-                              "column": 24,
-                              "line": 1,
-                              "offset": 23,
-                            },
-                            "indent": Array [],
-                            "start": Object {
-                              "column": 1,
-                              "line": 1,
-                              "offset": 0,
-                            },
-                          },
-                          "type": "paragraph",
-                        },
-                      ],
-                      "type": "paragraph",
-                    },
-                  ],
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "inlineCode",
-                          "value": "options.foxes",
                         },
                         Object {
                           "type": "text",
@@ -37174,6 +36974,206 @@ or any type information we could infer from annotations.",
                 },
               ],
               "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "fishesAndFoxes",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 42,
+              "line": 1,
+              "offset": 41,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This method has partially inferred params",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 42,
+          "line": 1,
+          "offset": 41,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Parameters",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "options",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "text",
+                          "value": "Object",
+                        },
+                      ],
+                      "identifier": "2",
+                      "referenceType": "full",
+                      "type": "linkReference",
+                    },
+                  ],
+                  "type": "strong",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+              ],
+              "type": "paragraph",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "inlineCode",
+                          "value": "options.fishes",
+                        },
+                        Object {
+                          "type": "text",
+                          "value": " ",
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "type": "text",
+                                  "value": "String",
+                                },
+                              ],
+                              "identifier": "3",
+                              "referenceType": "full",
+                              "type": "linkReference",
+                            },
+                          ],
+                          "type": "strong",
+                        },
+                        Object {
+                          "type": "text",
+                          "value": " ",
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Position {
+                                "end": Object {
+                                  "column": 24,
+                                  "line": 1,
+                                  "offset": 23,
+                                },
+                                "indent": Array [],
+                                "start": Object {
+                                  "column": 1,
+                                  "line": 1,
+                                  "offset": 0,
+                                },
+                              },
+                              "type": "text",
+                              "value": "number of kinds of fish",
+                            },
+                          ],
+                          "position": Position {
+                            "end": Object {
+                              "column": 24,
+                              "line": 1,
+                              "offset": 23,
+                            },
+                            "indent": Array [],
+                            "start": Object {
+                              "column": 1,
+                              "line": 1,
+                              "offset": 0,
+                            },
+                          },
+                          "type": "paragraph",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "listItem",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "inlineCode",
+                          "value": "options.foxes",
+                        },
+                        Object {
+                          "type": "text",
+                          "value": " ",
+                        },
+                        Object {
+                          "type": "text",
+                          "value": " ",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "listItem",
+                },
+              ],
+              "ordered": false,
+              "type": "list",
             },
           ],
           "type": "listItem",
@@ -42637,182 +42637,6 @@ Array [
       "loc": Object {
         "end": Object {
           "column": 2,
-          "line": 7,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 4,
-        },
-      },
-    },
-    "description": "",
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "class",
-    "loc": Object {
-      "end": Object {
-        "column": 13,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 3,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [
-        Object {
-          "augments": Array [],
-          "context": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 21,
-                "line": 6,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 6,
-              },
-            },
-          },
-          "description": Object {
-            "children": Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "position": Object {
-                      "end": Object {
-                        "column": 23,
-                        "line": 1,
-                        "offset": 22,
-                      },
-                      "indent": Array [],
-                      "start": Object {
-                        "column": 1,
-                        "line": 1,
-                        "offset": 0,
-                      },
-                    },
-                    "type": "text",
-                    "value": "The title of the book.",
-                  },
-                ],
-                "position": Object {
-                  "end": Object {
-                    "column": 23,
-                    "line": 1,
-                    "offset": 22,
-                  },
-                  "indent": Array [],
-                  "start": Object {
-                    "column": 1,
-                    "line": 1,
-                    "offset": 0,
-                  },
-                },
-                "type": "paragraph",
-              },
-            ],
-            "position": Object {
-              "end": Object {
-                "column": 23,
-                "line": 1,
-                "offset": 22,
-              },
-              "start": Object {
-                "column": 1,
-                "line": 1,
-                "offset": 0,
-              },
-            },
-            "type": "root",
-          },
-          "errors": Array [],
-          "examples": Array [],
-          "implements": Array [],
-          "loc": Object {
-            "end": Object {
-              "column": 31,
-              "line": 5,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 5,
-            },
-          },
-          "memberof": "Book",
-          "members": Object {
-            "events": Array [],
-            "global": Array [],
-            "inner": Array [],
-            "instance": Array [],
-            "static": Array [],
-          },
-          "name": "title",
-          "namespace": "Book#title",
-          "params": Array [],
-          "path": Array [
-            Object {
-              "kind": "class",
-              "name": "Book",
-            },
-            Object {
-              "name": "title",
-              "scope": "instance",
-            },
-          ],
-          "properties": Array [],
-          "returns": Array [],
-          "scope": "instance",
-          "sees": Array [],
-          "tags": Array [],
-          "throws": Array [],
-          "todos": Array [],
-          "yields": Array [],
-        },
-      ],
-      "static": Array [],
-    },
-    "name": "Book",
-    "namespace": "Book",
-    "params": Array [
-      Object {
-        "lineNumber": 4,
-        "name": "title",
-        "title": "param",
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "class",
-        "name": "Book",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [
-      Object {
-        "description": null,
-        "lineNumber": 0,
-        "name": null,
-        "title": "class",
-      },
-    ],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 2,
           "line": 13,
         },
         "start": Object {
@@ -42983,6 +42807,182 @@ Array [
     "todos": Array [],
     "yields": Array [],
   },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 2,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 4,
+        },
+      },
+    },
+    "description": "",
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "class",
+    "loc": Object {
+      "end": Object {
+        "column": 13,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 3,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 21,
+                "line": 6,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 6,
+              },
+            },
+          },
+          "description": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "end": Object {
+                        "column": 23,
+                        "line": 1,
+                        "offset": 22,
+                      },
+                      "indent": Array [],
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                        "offset": 0,
+                      },
+                    },
+                    "type": "text",
+                    "value": "The title of the book.",
+                  },
+                ],
+                "position": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 1,
+                    "offset": 22,
+                  },
+                  "indent": Array [],
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "position": Object {
+              "end": Object {
+                "column": 23,
+                "line": 1,
+                "offset": 22,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "type": "root",
+          },
+          "errors": Array [],
+          "examples": Array [],
+          "implements": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 31,
+              "line": 5,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 5,
+            },
+          },
+          "memberof": "Book",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "title",
+          "namespace": "Book#title",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": "class",
+              "name": "Book",
+            },
+            Object {
+              "name": "title",
+              "scope": "instance",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "instance",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+          "yields": Array [],
+        },
+      ],
+      "static": Array [],
+    },
+    "name": "Book",
+    "namespace": "Book",
+    "params": Array [
+      Object {
+        "lineNumber": 4,
+        "name": "title",
+        "title": "param",
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "class",
+        "name": "Book",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [
+      Object {
+        "description": null,
+        "lineNumber": 0,
+        "name": null,
+        "title": "class",
+      },
+    ],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
 ]
 `;
 
@@ -42992,24 +42992,14 @@ exports[`outputs this-class.input.js markdown 1`] = `
 ### Table of Contents
 
 -   [bookshelf][1]
--   [Book][2]
+-   [BookShelf][2]
     -   [Parameters][3]
     -   [title][4]
--   [BookShelf][5]
+-   [Book][5]
     -   [Parameters][6]
     -   [title][7]
 
 ## bookshelf
-
-## Book
-
-### Parameters
-
--   \`title\`  
-
-### title
-
-The title of the book.
 
 ## BookShelf
 
@@ -43021,15 +43011,25 @@ The title of the book.
 
 The title of the bookshelf.
 
+## Book
+
+### Parameters
+
+-   \`title\`  
+
+### title
+
+The title of the book.
+
 [1]: #bookshelf
 
-[2]: #book
+[2]: #bookshelf-1
 
 [3]: #parameters
 
 [4]: #title
 
-[5]: #bookshelf-1
+[5]: #book
 
 [6]: #parameters-1
 
@@ -43053,99 +43053,6 @@ Object {
       ],
       "depth": 2,
       "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Book",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Parameters",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "title",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ],
-          "type": "listItem",
-        },
-      ],
-      "ordered": false,
-      "type": "list",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "title",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 23,
-              "line": 1,
-              "offset": 22,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "text",
-          "value": "The title of the book.",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 23,
-          "line": 1,
-          "offset": 22,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
     },
     Object {
       "children": Array [
@@ -43230,6 +43137,99 @@ Object {
           "column": 28,
           "line": 1,
           "offset": 27,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Book",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Parameters",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "title",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+                Object {
+                  "type": "text",
+                  "value": " ",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "title",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 23,
+              "line": 1,
+              "offset": 22,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "The title of the book.",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
         },
         "indent": Array [],
         "start": Object {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "documentation",
   "description": "a documentation generator",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "author": "Tom MacWright",
   "bin": {
     "documentation": "./bin/documentation.js"

--- a/src/parsers/javascript.js
+++ b/src/parsers/javascript.js
@@ -77,7 +77,7 @@ function _addComment(
     }*/ = {
       loc: nodeLoc,
       file: data.file,
-      sortKey: data.sortKey + ' ' + leftPad(nodeLoc.start.line, 8)
+      sortKey: key + ' ' + leftPad(nodeLoc.start.line, 8)
     };
 
     if (includeContext) {


### PR DESCRIPTION
Background and Motivation
---
Comment sort is not stable because they are sorted using `data.sortKey` which uses source code's location, instead of comment's location.

What Changes in this PR
---
This PR resolves that by using `key` instead of `data.sortKey`.